### PR TITLE
Fix numpy transitive dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python-dotenv~=1.0.1
 pytest~=8.1.1
 tqdm~=4.66.2
 pandas~=1.5.3
+numpy==1.26.4


### PR DESCRIPTION
pandas dependency on numpy doesn't specify a version strict enough leading to the usage of Numpy 2 whereas only be compatible with Numpy 1. This lead to the following error:
`ValueError: numpy.dtype size changed, may indicate binary incompatibility.`

Fixing explicitly the Numpy version to the latest release of branch 1 with the issue.